### PR TITLE
Update create_status to pass media IDs as array #9

### DIFF
--- a/lib/mastodon/rest/statuses.rb
+++ b/lib/mastodon/rest/statuses.rb
@@ -12,7 +12,12 @@ module Mastodon
       # @param media_ids [Array<Integer>]
       # @return [Mastodon::Status]
       def create_status(text, in_reply_to_id = nil, media_ids = [])
-        perform_request_with_object(:post, '/api/v1/statuses', array_param(:media_ids, media_ids).merge(status: text, in_reply_to_id: in_reply_to_id), Mastodon::Status)
+        params = {
+          status: text,
+          in_reply_to_id: in_reply_to_id,
+          'media_ids[]' => media_ids,
+        }
+        perform_request_with_object(:post, '/api/v1/statuses', params, Mastodon::Status)
       end
 
       # Retrieve status

--- a/spec/fixtures/requests/create-status-with-media.json
+++ b/spec/fixtures/requests/create-status-with-media.json
@@ -1,0 +1,17 @@
+HTTP/1.1 200 OK
+Server: nginx/1.9.3 (Ubuntu)
+Date: Thu, 20 Oct 2016 15:33:11 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+X-Frame-Options: SAMEORIGIN
+X-XSS-Protection: 1; mode=block
+X-Content-Type-Options: nosniff
+Vary: Accept-Encoding
+ETag: W/"2296aebbb82bec23848d5a1c5dd01838"
+Cache-Control: max-age=0, private, must-revalidate
+Set-Cookie: _mastodon_session=MkhuVGx2Y1V3WlA3OER0blA5UlBSUFRZUzJVYXdQRUY2U0tQTG1OUDFvN2xDcTNaMThwWGg4Umg5V2xkbUgyNk1lYUo3citTeTBOL0NEUURndko0R2FvWElNMTludXhzTUZpZ3dkV1o4SThzWGtud0M1ZzNCT05DWHhYL0V2YlgtLVppMG0ySHhJY0h6ZXluaFR5dHhjRUE9PQ%3D%3D--e9c63b98fff0d292a0562f6a482533f80eac36c3; path=/; HttpOnly
+X-Request-Id: a1fb8891-6e72-44ae-ac15-05ce924f8dda
+X-Runtime: 0.087240
+
+{"id":16745,"created_at":"2017-04-10T14:56:49.219Z","in_reply_to_id":null,"in_reply_to_account_id":null,"sensitive":null,"spoiler_text":"","visibility":"public","application":{"name":"tester","website":""},"account":{"id":2430,"username":"tester","acct":"tester","display_name":"","locked":false,"created_at":"2017-04-10T13:40:14.838Z","note":"","url":"https://botsin.space/@tester","avatar":"/avatars/original/missing.png","header":"/headers/original/missing.png","followers_count":0,"following_count":0,"statuses_count":2},"media_attachments":[{"id":1467,"remote_url":"","type":"image","url":"https://botsinspace.s3.amazonaws.com/media_attachments/files/000/001/467/original/3369e3e50e4dce97.png?1491836194","preview_url":"https://botsinspace.s3.amazonaws.com/media_attachments/files/000/001/467/small/3369e3e50e4dce97.png?1491836194","text_url":"https://botsin.space/media/MfCqN_C2FFEeWoxiX2E"}],"mentions":[],"tags":[],"uri":"tag:botsin.space,2017-04-10:objectId=16745:objectType=Status","content":"<p>test!</p>","url":"https://botsin.space/@tester/16745","reblogs_count":0,"favourites_count":0,"reblog":null,"favourited":false,"reblogged":false}

--- a/spec/mastodon/rest/statuses_spec.rb
+++ b/spec/mastodon/rest/statuses_spec.rb
@@ -17,6 +17,14 @@ describe Mastodon::REST::Statuses do
       stub_request(:post, 'https://mastodon.social/api/v1/statuses').to_return(fixture('create-status-no-text.json'))
       expect { @client.create_status('') }.to raise_error Mastodon::Error::UnprocessableEntity
     end
+
+    it 'returns media when specified' do
+      stub_request(:post, 'https://mastodon.social/api/v1/statuses').to_return(fixture('create-status-with-media.json'))
+      status = @client.create_status('test!', nil, [1467])
+      expect(status).to be_a Mastodon::Status
+      expect(status.content).to match(/test!/)
+      expect(status.media_attachments.first).to be_a Mastodon::Entities::Media
+    end
   end
 
   describe '#status' do


### PR DESCRIPTION
This should fix #9.

Uploading media from the client is 100% non-functional right now. As a side note, it's failing silently, I can try and submit a PR to mastodon for that later.