### PR TITLE
Optionally accept a hash of parameters to create a status

### DIFF
--- a/spec/mastodon/rest/statuses_spec.rb
+++ b/spec/mastodon/rest/statuses_spec.rb
@@ -25,6 +25,46 @@ describe Mastodon::REST::Statuses do
       expect(status.content).to match(/test!/)
       expect(status.media_attachments.first).to be_a Mastodon::Entities::Media
     end
+
+    describe 'API parameters' do
+      def expected_params(opts)
+        opts = {
+          :in_reply_to_id => nil,
+          'media_ids[]' => nil,
+          :visibility => nil,
+        }.merge(opts)
+
+        expect(@client).to receive(:perform_request_with_object).with(:post, '/api/v1/statuses', opts, Mastodon::Status)
+      end
+
+      it 'works with status' do
+        expected_params(status: 'hello')
+        @client.create_status('hello')
+      end
+
+      it 'works with status and in_reply_to' do
+        expected_params(status: 'hello', in_reply_to_id: 12_345)
+        @client.create_status('hello', 12_345)
+      end
+
+      it 'works with status, in_reply_to, and media_ids' do
+        expected_params(status: 'hello', in_reply_to_id: 12_345, 'media_ids[]' => [1, 2, 3])
+        @client.create_status('hello', 12_345, [1, 2, 3])
+      end
+
+      it 'works with status, in_reply_to, media_ids, and visibility' do
+        expected_params(status: 'hello', in_reply_to_id: 12_345, 'media_ids[]' => [1, 2, 3], visibility: 'public')
+        @client.create_status('hello', 12_345, [1, 2, 3], 'public')
+      end
+
+      it 'works with params hash' do
+        expected_params(status: 'hello', in_reply_to_id: 12_345, 'media_ids[]' => [1, 2, 3], visibility: 'public')
+        @client.create_status('hello',
+                              in_reply_to_id: 12_345,
+                              media_ids: [1, 2, 3],
+                              visibility: 'public')
+      end
+    end
   end
 
   describe '#status' do


### PR DESCRIPTION
This updates the `create_status` method to accept a hash of parameters, while maintaining compatibility with passing in individual parameters if needed. In my opinion, this makes it easier to implement clients that might want to pass data to the API without worrying about exactly what they are sending, parameter ordering, etc. It also makes it a lot easier to support adding additional parameters in the future.