### PR TITLE
Add support for media description

### DIFF
--- a/lib/mastodon/rest/media.rb
+++ b/lib/mastodon/rest/media.rb
@@ -9,10 +9,14 @@ module Mastodon
       # Upload a media file
       # @param file [File, StringIO, HTTP::FormData::File] file to
       #   upload. Will be converted to HTTP::FormData::File before upload
+      # @param description [String] A text description of the image, to be
+      #   along with the image.
       # @return [Mastodon::Media]
-      def upload_media(file)
+      def upload_media(file, description = nil)
         file = file.is_a?(HTTP::FormData::File) ? file : HTTP::FormData::File.new(file)
-        perform_request_with_object(:post, '/api/v1/media', { file: file }, Mastodon::Media)
+        payload = { file: file }
+        payload.merge!(description: description) unless description.nil?
+        perform_request_with_object(:post, '/api/v1/media', payload, Mastodon::Media)
       end
     end
   end

--- a/spec/mastodon/rest/media_spec.rb
+++ b/spec/mastodon/rest/media_spec.rb
@@ -13,6 +13,12 @@ describe Mastodon::REST::Media do
       expect(media).to be_a Mastodon::Media
     end
 
+    it 'works with a description' do
+      path = File.join(File.dirname(__FILE__), '..', '..', 'fixtures', 'upload.png')
+      expect(@client).to receive(:perform_request_with_object).with(anything, anything, hash_including(:description => 'Lorem ipsum'), anything)
+      media = @client.upload_media(File.new(path), 'Lorem ipsum')
+    end
+
     it 'works with a StringIO' do
       media = @client.upload_media(StringIO.new)
       expect(media).to be_a Mastodon::Media


### PR DESCRIPTION
This adds support for the changes in the API that enable describing an image. It also adds a test that when a description is received, it's passed forward.