### PR TITLE
Add support for editing media description

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ notifications:
 rvm:
   - 2.1
   - 2.2
+  - 2.3
+  - 2.4
+  - 2.5
   - ruby-head
 
 bundler_args: --without development --retry=3 --jobs=3

--- a/lib/mastodon/rest/media.rb
+++ b/lib/mastodon/rest/media.rb
@@ -18,6 +18,15 @@ module Mastodon
         payload.merge!(description: description) unless description.nil?
         perform_request_with_object(:post, '/api/v1/media', payload, Mastodon::Media)
       end
+
+      # Update a media description, can only be updated while it's not associated to a status
+      # @param media_id [Integer] Id of the media, returned by upload_media
+      # @param description [String] A text description of the image, to be
+      #   along with the image.
+      # @return [Mastodon::Media]
+      def update_media_description(media_id, description)
+        perform_request_with_object(:put, "/api/v1/media/#{media_id}", {description: description}, Mastodon::Media)
+      end
     end
   end
 end


### PR DESCRIPTION
Adding media description when uploading the image is supported, but creates issues with descriptions that contain utf-8 characters. The two-step approach (upload, add description) is better for these cases.