### PR TITLE
Add headers from options to rest requests

### DIFF
--- a/lib/mastodon/rest/request.rb
+++ b/lib/mastodon/rest/request.rb
@@ -14,6 +14,7 @@ module Mastodon
         @headers        = Mastodon::Headers.new(@client).request_headers
         @path           = @uri.path
         @options        = options
+        @headers        = @options.delete(:headers).merge @headers if @options.is_a?(Hash) && @options[:headers]
       end
 
       def perform

--- a/spec/mastodon/rest/statuses_spec.rb
+++ b/spec/mastodon/rest/statuses_spec.rb
@@ -18,6 +18,15 @@ describe Mastodon::REST::Statuses do
       expect { @client.create_status('') }.to raise_error Mastodon::Error::UnprocessableEntity
     end
 
+    it 'accepts request with headers' do
+      stub_request(:post, 'https://mastodon.social/api/v1/statuses')
+        .with(headers: { 'Idempotency-Key' => '1234567890' })
+        .to_return(fixture('create-status-only-text.json'))
+      status = @client.create_status('Writing a ruby API lib for Mastodon', headers: { 'Idempotency-Key' => '1234567890' })
+      expect(status).to be_a Mastodon::Status
+      expect(status.content).to match(/Writing a ruby API lib for Mastodon/)
+    end
+
     it 'returns media when specified' do
       stub_request(:post, 'https://mastodon.social/api/v1/statuses').to_return(fixture('create-status-with-media.json'))
       status = @client.create_status('test!', nil, [1467])


### PR DESCRIPTION
This allows to use things like the Idempotency-Key headers. The original headers have precedency, so that the authorization and user agent cannot be overwritten.