### PR TITLE
Set hostname for ssl_client for server that needs SNI

### DIFF
--- a/lib/mastodon/streaming/connection.rb
+++ b/lib/mastodon/streaming/connection.rb
@@ -28,8 +28,9 @@ module Mastodon
 
         return client if !@using_ssl || (!@using_ssl && request.using_proxy?)
 
-        client_context = OpenSSL::SSL::SSLContext.new
-        ssl_client     = @ssl_socket_class.new(client, client_context)
+        client_context      = OpenSSL::SSL::SSLContext.new
+        ssl_client          = @ssl_socket_class.new(client, client_context)
+        ssl_client.hostname = request.socket_host
 
         ssl_client.connect
       end


### PR DESCRIPTION
This prevents the error
```
lib/mastodon/streaming/connection.rb:35:in `connect': SSL_connect returned=1 errno=0 state=SSLv2/v3 read server hello A: sslv3 alert handshake failure (OpenSSL::SSL::SSLError)
```
for `Mastodon::Streaming::Client.new(base_url: "https://#{server}" bearer_token: token).user(){|toot| ... }` on a server that requires SNI to establish TLS connection.