### PR TITLE
Add methods to retrieve max_id/since_id for collections.

### DIFF
--- a/lib/mastodon/collection.rb
+++ b/lib/mastodon/collection.rb
@@ -2,8 +2,25 @@ module Mastodon
   class Collection
     include ::Enumerable
 
-    def initialize(items, klass)
+    def initialize(items, klass, headers = nil)
       @collection = items.map { |attributes| klass.new(attributes) }
+      @link = {}
+      (headers ? headers.get("Link") : []).each do |link_values|
+        link_values.split(",").map(&:strip).each do |link_value|
+          uri_ref_part, *link_params = link_value.split(";").map(&:strip)
+          next unless uri_ref_part && uri_ref_part =~ /\A<(.*)>\z/
+          uri_ref = $1
+          rel_types_raw = link_params.find { |param| break $1 if param =~ /\Arel=(.*)\z/ }
+          if rel_types_raw =~ /\A"(.*)"\z/
+            rel_types = $1.split(/\s+/)
+          else
+            rel_types = [rel_types_raw].compact
+          end
+          rel_types.each do |rel_type|
+            @link[rel_type] = uri_ref
+          end
+        end
+      end
     end
 
     def each(start = 0)
@@ -22,6 +39,18 @@ module Mastodon
 
     def last
       @collection.last
+    end
+
+    def next_max_id
+      return unless @link["next"]
+      uri = Addressable::URI.parse(@link["next"])
+      uri.query_values["max_id"].to_i
+    end
+
+    def prev_since_id
+      return unless @link["prev"]
+      uri = Addressable::URI.parse(@link["prev"])
+      uri.query_values["since_id"].to_i
     end
   end
 end

--- a/lib/mastodon/rest/utils.rb
+++ b/lib/mastodon/rest/utils.rb
@@ -13,6 +13,13 @@ module Mastodon
       # @param request_method [Symbol]
       # @param path [String]
       # @param options [Hash]
+      def perform_request_with_headers(request_method, path, options = {})
+        Mastodon::REST::Request.new(self, request_method, path, options).perform_with_headers
+      end
+
+      # @param request_method [Symbol]
+      # @param path [String]
+      # @param options [Hash]
       # @param klass [Class]
       def perform_request_with_object(request_method, path, options, klass)
         response = perform_request(request_method, path, options)
@@ -24,8 +31,8 @@ module Mastodon
       # @param options [Hash]
       # @param klass [Class]
       def perform_request_with_collection(request_method, path, options, klass)
-        response = perform_request(request_method, path, options)
-        Mastodon::Collection.new(response, klass)
+        response, headers = perform_request_with_headers(request_method, path, options)
+        Mastodon::Collection.new(response, klass, headers)
       end
 
       # Format an array of values into a query param


### PR DESCRIPTION
This is not a polished PR (which emerged from my personal, one-shot use), but I'm submitting this in case someone wants this feature.

This method is necessary when e.g. one wants to iterate through all followings or all followers of a user. I used this to extract all my followings in the `friends.nico` instance (because the server will be shut down soon)