### PR TITLE
Fix Build and HTTP Parser Call

### DIFF
--- a/lib/mastodon/streaming/connection.rb
+++ b/lib/mastodon/streaming/connection.rb
@@ -1,4 +1,3 @@
-require 'http/parser'
 require 'openssl'
 require 'resolv'
 

--- a/spec/mastodon/streaming/connection_spec.rb
+++ b/spec/mastodon/streaming/connection_spec.rb
@@ -62,6 +62,7 @@ describe Mastodon::Streaming::Connection do
     it 'requests via the proxy' do
       expect(connection.ssl_socket_class).to receive(:new).and_return(ssl_socket)
       allow(ssl_socket).to receive(:connect)
+      allow(ssl_socket).to receive(:hostname=).with('mastodon.social')
 
       expect(connection).to receive(:new_tcp_socket).with('mastodon.social', 443)
       connection.connect(request)


### PR DESCRIPTION
The HTTP gem changed its underlying http parser library to a different
gem, and that broke the streaming response code that is in this gem,
causing an error when trying to load it. This fix uses the HTTP gem's
streaming API, not `http-parser` itself, so it should be a little more
immune from these breaking changes.