### PR TITLE
Fix update media method, add spec

### DIFF
--- a/lib/mastodon/rest/media.rb
+++ b/lib/mastodon/rest/media.rb
@@ -24,7 +24,7 @@ module Mastodon
       # @option params :focus [String] Two floating points, comma-delimited
       # @return [Mastodon::Media]
       def update_media(id, params)
-        perform_request_with_object(:put, "/api/v1/media/#{media_id}", params, Mastodon::Media)
+        perform_request_with_object(:put, "/api/v1/media/#{id}", params, Mastodon::Media)
       end
     end
   end

--- a/spec/mastodon/rest/media_spec.rb
+++ b/spec/mastodon/rest/media_spec.rb
@@ -31,4 +31,17 @@ describe Mastodon::REST::Media do
       expect(media).to be_a Mastodon::Media
     end
   end
+
+  describe '#update_media' do
+    let (:media_id) { 123 }
+    it 'sends the two possible params over' do
+      opts = { description: 'A test description', focus: '1.0,2.3' }
+
+      stub_request(:put, 'https://mastodon.social/api/v1/media/123').
+        with(body: opts).
+        to_return(fixture('media.json'))
+      media = @client.update_media(media_id, opts)
+      expect(media).to be_a Mastodon::Media
+    end
+  end
 end


### PR DESCRIPTION
The update_media method was trying to use a media_id variable which was changed in 4e75bec