### PR TITLE
Added new instruction to usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ All the documentation is available on [RubyDoc](http://www.rubydoc.info/gems/mas
 
 Assuming that you already have an access token for a user on a given Mastodon instance:
 
+    require 'mastodon'
+
     client = Mastodon::REST::Client.new(base_url: 'https://mastodon.social', bearer_token: 'your_access_token')
 
 If you need to get an access token, you must first ensure that you have the client ID and client secret for your app on the given Mastodon instance (you should save those for future calls):


### PR DESCRIPTION
When using the API through this gem, the user can be a little confused when receiving the error `mastodon not defined`. So, it is interesting to add the require 'mastodon' making it clearer how the sample code is used