### PR TITLE
Add missing REST endpoints

### DIFF
--- a/lib/mastodon/announcement.rb
+++ b/lib/mastodon/announcement.rb
@@ -1,0 +1,47 @@
+require 'mastodon/announcement_reaction'
+
+module Mastodon
+  class Announcement < Mastodon::Base
+    # @!attribute [r] id
+    #   @return [String]
+    # @!attribute [r] text
+    #   @return [String]
+    # @!attribute [r] published?
+    #   @return [Boolean]
+    # @!attribute [r] all_day?
+    #   @return [Boolean]
+    # @!attribute [r] created_at
+    #   @return [String]
+    # @!attribute [r] updated_at
+    #   @return [String]
+    # @!attribute [r] read?
+    #   @return [Boolean]
+    # @!attribute [r] reactions
+    #   @return [Mastodon::Collection<Mastodon::AnnouncementReaction>]
+    # @!attribute [r] scheduled_at
+    #   @return [String]
+    # @!attribute [r] starts_at
+    #   @return [String]
+    # @!attribute [r] ends_at
+    #   @return [String]
+
+    normal_attr_reader :id,
+                       :text,
+                       :created_at,
+                       :updated_at,
+                       :scheduled_at,
+                       :starts_at,
+                       :ends_at
+
+    predicate_attr_reader :published,
+                          :all_day,
+                          :read
+
+    collection_attr_reader :reactions, Mastodon::AnnouncementReaction
+
+    def initialize(attributes = {})
+      attributes.fetch('id')
+      super
+    end
+  end
+end

--- a/lib/mastodon/announcement_reaction.rb
+++ b/lib/mastodon/announcement_reaction.rb
@@ -1,0 +1,26 @@
+module Mastodon
+  class AnnouncementReaction < Mastodon::Base
+    # @!attribute [r] name
+    #   @return [String]
+    # @!attribute [r] count
+    #   @return [Integer]
+    # @!attribute [r] me?
+    #   @return [Boolean]
+    # @!attribute [r] url
+    #   @return [String]
+    # @!attribute [r] static_url
+    #   @return [String]
+
+    normal_attr_reader :name,
+                       :count,
+                       :url,
+                       :static_url
+
+    predicate_attr_reader :me
+
+    def initialize(attributes = {})
+      attributes.fetch('name')
+      super
+    end
+  end
+end

--- a/lib/mastodon/featured_tag.rb
+++ b/lib/mastodon/featured_tag.rb
@@ -1,0 +1,17 @@
+module Mastodon
+  class FeaturedTag < Mastodon::Base
+    # @!attribute [r] id
+    #   @return [String]
+    # @!attribute [r] name
+    #   @return [String]
+    # @!attribute [r] statuses_count
+    #   @return [String]
+    # @!attribute [r] last_status_at
+    #   @return [String]
+
+    normal_attr_reader :id,
+                       :name,
+                       :statuses_count,
+                       :last_status_at
+  end
+end

--- a/lib/mastodon/identity_proof.rb
+++ b/lib/mastodon/identity_proof.rb
@@ -1,0 +1,20 @@
+module Mastodon
+  class IdentityProof < Mastodon::Base
+    # @!attribute [r] provider
+    #   @return [String]
+    # @!attribute [r] provider_username
+    #   @return [String]
+    # @!attribute [r] updated_at
+    #   @return [String]
+    # @!attribute [r] proof_url
+    #   @return [String]
+    # @!attribute [r] profile_url
+    #   @return [String]
+
+    normal_attr_reader :provider,
+                       :provider_username,
+                       :updated_at,
+                       :proof_url,
+                       :profile_url
+  end
+end

--- a/lib/mastodon/poll.rb
+++ b/lib/mastodon/poll.rb
@@ -1,0 +1,42 @@
+module Mastodon
+  class Poll < Mastodon::Base
+    # @!attribute [r] id
+    #   @return [String]
+    # @!attribute [r] expires_at
+    #   @return [String]
+    # @!attribute [r] votes_count
+    #   @return [Integer]
+    # @!attribute [r] voters_count
+    #   @return [Integer]
+    # @!attribute [r] expired?
+    #   @return [Boolean]
+    # @!attribute [r] voted?
+    #   @return [Boolean]
+    # @!attribute [r] multiple?
+    #   @return [Boolean]
+    # @!attribute [r] own_votes
+    #   @return [Array<Integer>]
+    # @!attribute [r] options
+    #   @return [Array<Hash>]
+    # @!attribute [r] emojis
+    #   @return [Mastodon::Collection<Mastodon::Emoji>]
+
+    normal_attr_reader :id,
+                       :expires_at,
+                       :votes_count,
+                       :voters_count,
+                       :own_votes,
+                       :options
+
+    predicate_attr_reader :voted,
+                          :multiple,
+                          :expired
+
+    collection_attr_reader :emojis, Mastodon::Emoji
+
+    def initialize(attributes = {})
+      attributes.fetch('id')
+      super
+    end
+  end
+end

--- a/lib/mastodon/poll.rb
+++ b/lib/mastodon/poll.rb
@@ -1,3 +1,5 @@
+require 'mastodon/emoji'
+
 module Mastodon
   class Poll < Mastodon::Base
     # @!attribute [r] id

--- a/lib/mastodon/push_subscription.rb
+++ b/lib/mastodon/push_subscription.rb
@@ -1,0 +1,22 @@
+module Mastodon
+  class PushSubscription < Mastodon::Base
+    # @!attribute [r] id
+    #   @return [String]
+    # @!attribute [r] endpoint
+    #   @return [String]
+    # @!attribute [r] server_key
+    #   @return [String]
+    # @!attribute [r] alerts
+    #   @return [Hash]
+
+    normal_attr_reader :id,
+                       :endpoint,
+                       :server_key,
+                       :alerts
+
+    def initialize(attributes = {})
+      attributes.fetch('id')
+      super
+    end
+  end
+end

--- a/lib/mastodon/rest/accounts.rb
+++ b/lib/mastodon/rest/accounts.rb
@@ -1,6 +1,7 @@
 require 'mastodon/rest/utils'
 require 'mastodon/account'
 require 'mastodon/access_token'
+require 'mastodon/identity_proof'
 
 module Mastodon
   module REST
@@ -81,6 +82,13 @@ module Mastodon
       # @return [Mastodon::Collection<Mastodon::Account>]
       def search_accounts(query, params = {})
         perform_request_with_collection(:get, '/api/v1/accounts/search', { q: query }.merge(params), Mastodon::Account)
+      end
+
+      # List of account identity proofs
+      # @param id [Integer]
+      # @return [Mastodon::Collection<Mastodon::IdentityProof>]
+      def identity_proofs(id)
+        perform_request_with_collection(:get, "/api/v1/accounts/#{id}/identity_proofs", options, Mastodon::IdentityProof)
       end
     end
   end

--- a/lib/mastodon/rest/announcements.rb
+++ b/lib/mastodon/rest/announcements.rb
@@ -1,0 +1,37 @@
+require 'mastodon/rest/utils'
+require 'mastodon/announcement'
+
+module Mastodon
+  module REST
+    module Announcements
+      include Mastodon::REST::Utils
+
+      # See all currently active announcements set by admins for this instance
+      # @param with_dismissed [Boolean]
+      # @return [Mastodon::Collection<Mastodon::Announcement>]
+      def announcements(with_dismissed = false)
+        perform_request_with_collection(:get, '/api/v1/announcements/', { 'with_dismissed': with_dismissed }, Mastodon::Announcement)
+      end
+
+      # Dismiss an announcement
+      # @param announcement_id [Integer]
+      def dismiss_announcement(announcement_id)
+        perform_request(:post, "/api/v1/announcements/#{announcement_id}", {})
+      end
+
+      # Dismiss an announcement
+      # @param announcement_id [Integer]
+      # @param emoji [String]
+      def add_annoucement_reaction(announcement_id, emoji)
+        perform_request(:put, "/api/v1/announcements/#{announcement_id}/reactions/#{emoji}", {})
+      end
+
+      # Dismiss an announcement
+      # @param announcement_id [Integer]
+      # @param emoji [String]
+      def remove_annoucement_reaction(announcement_id, emoji)
+        perform_request(:delete, "/api/v1/announcements/#{announcement_id}/reactions/#{emoji}", {})
+      end
+    end
+  end
+end

--- a/lib/mastodon/rest/api.rb
+++ b/lib/mastodon/rest/api.rb
@@ -17,6 +17,7 @@ require 'mastodon/rest/reports'
 require 'mastodon/rest/lists'
 require 'mastodon/rest/scheduled_statuses'
 require 'mastodon/rest/conversations'
+require 'mastodon/rest/favourites'
 
 module Mastodon
   module REST
@@ -40,6 +41,7 @@ module Mastodon
       include Mastodon::REST::Lists
       include Mastodon::REST::ScheduledStatuses
       include Mastodon::REST::Conversations
+      include Mastodon::REST::Favourites
     end
   end
 end

--- a/lib/mastodon/rest/api.rb
+++ b/lib/mastodon/rest/api.rb
@@ -18,6 +18,7 @@ require 'mastodon/rest/lists'
 require 'mastodon/rest/scheduled_statuses'
 require 'mastodon/rest/conversations'
 require 'mastodon/rest/favourites'
+require 'mastodon/rest/featured_tags'
 
 module Mastodon
   module REST
@@ -42,6 +43,7 @@ module Mastodon
       include Mastodon::REST::ScheduledStatuses
       include Mastodon::REST::Conversations
       include Mastodon::REST::Favourites
+      include Mastodon::REST::FeaturedTags
     end
   end
 end

--- a/lib/mastodon/rest/api.rb
+++ b/lib/mastodon/rest/api.rb
@@ -24,6 +24,7 @@ require 'mastodon/rest/polls'
 require 'mastodon/rest/push_subscriptions'
 require 'mastodon/rest/directory'
 require 'mastodon/rest/trends'
+require 'mastodon/rest/announcements'
 
 module Mastodon
   module REST
@@ -54,6 +55,7 @@ module Mastodon
       include Mastodon::REST::PushSubscriptions
       include Mastodon::REST::Directory
       include Mastodon::REST::Trends
+      include Mastodon::REST::Announcements
     end
   end
 end

--- a/lib/mastodon/rest/api.rb
+++ b/lib/mastodon/rest/api.rb
@@ -22,6 +22,7 @@ require 'mastodon/rest/featured_tags'
 require 'mastodon/rest/oauth'
 require 'mastodon/rest/polls'
 require 'mastodon/rest/push_subscriptions'
+require 'mastodon/rest/directory'
 
 module Mastodon
   module REST
@@ -50,6 +51,7 @@ module Mastodon
       include Mastodon::REST::OAuth
       include Mastodon::REST::Polls
       include Mastodon::REST::PushSubscriptions
+      include Mastodon::REST::Directory
     end
   end
 end

--- a/lib/mastodon/rest/api.rb
+++ b/lib/mastodon/rest/api.rb
@@ -23,6 +23,7 @@ require 'mastodon/rest/oauth'
 require 'mastodon/rest/polls'
 require 'mastodon/rest/push_subscriptions'
 require 'mastodon/rest/directory'
+require 'mastodon/rest/trends'
 
 module Mastodon
   module REST
@@ -52,6 +53,7 @@ module Mastodon
       include Mastodon::REST::Polls
       include Mastodon::REST::PushSubscriptions
       include Mastodon::REST::Directory
+      include Mastodon::REST::Trends
     end
   end
 end

--- a/lib/mastodon/rest/api.rb
+++ b/lib/mastodon/rest/api.rb
@@ -20,6 +20,7 @@ require 'mastodon/rest/conversations'
 require 'mastodon/rest/favourites'
 require 'mastodon/rest/featured_tags'
 require 'mastodon/rest/oauth'
+require 'mastodon/rest/polls'
 
 module Mastodon
   module REST
@@ -46,6 +47,7 @@ module Mastodon
       include Mastodon::REST::Favourites
       include Mastodon::REST::FeaturedTags
       include Mastodon::REST::OAuth
+      include Mastodon::REST::Polls
     end
   end
 end

--- a/lib/mastodon/rest/api.rb
+++ b/lib/mastodon/rest/api.rb
@@ -19,6 +19,7 @@ require 'mastodon/rest/scheduled_statuses'
 require 'mastodon/rest/conversations'
 require 'mastodon/rest/favourites'
 require 'mastodon/rest/featured_tags'
+require 'mastodon/rest/oauth'
 
 module Mastodon
   module REST
@@ -44,6 +45,7 @@ module Mastodon
       include Mastodon::REST::Conversations
       include Mastodon::REST::Favourites
       include Mastodon::REST::FeaturedTags
+      include Mastodon::REST::OAuth
     end
   end
 end

--- a/lib/mastodon/rest/api.rb
+++ b/lib/mastodon/rest/api.rb
@@ -21,6 +21,7 @@ require 'mastodon/rest/favourites'
 require 'mastodon/rest/featured_tags'
 require 'mastodon/rest/oauth'
 require 'mastodon/rest/polls'
+require 'mastodon/rest/push_subscriptions'
 
 module Mastodon
   module REST
@@ -48,6 +49,7 @@ module Mastodon
       include Mastodon::REST::FeaturedTags
       include Mastodon::REST::OAuth
       include Mastodon::REST::Polls
+      include Mastodon::REST::PushSubscriptions
     end
   end
 end

--- a/lib/mastodon/rest/directory.rb
+++ b/lib/mastodon/rest/directory.rb
@@ -1,0 +1,21 @@
+require 'mastodon/rest/utils'
+require 'mastodon/account'
+
+module Mastodon
+  module REST
+    module Directory
+      include Mastodon::REST::Utils
+
+      # List accounts visible in the directory
+      # @param options [Hash]
+      # @option options :offset [String]
+      # @option options :limit [String]
+      # @option options :order [String]
+      # @option options :local [Boolean]
+      # @return [Mastodon::Collection<Mastodon::Account>]
+      def view_directory(options = {})
+        perform_request_with_collection(:get, '/api/v1/directory', options, Mastodon::Account)
+      end
+    end
+  end
+end

--- a/lib/mastodon/rest/favourites.rb
+++ b/lib/mastodon/rest/favourites.rb
@@ -1,0 +1,20 @@
+require 'mastodon/rest/utils'
+require 'mastodon/status'
+
+module Mastodon
+  module REST
+    module Favourites
+      include Mastodon::REST::Utils
+
+      # Get a list of statuses that the current user has favourited
+      # @param options [Hash]
+      # @option options :limit [String]
+      # @option options :min_id [Integer]
+      # @option options :max_id [Integer]
+      # @return [Mastodon::Collection<Mastodon::Status>]
+      def favourites(options = {})
+        perform_request_with_collection(:get, "/api/v1/favourites", options, Mastodon::Status)
+      end
+    end
+  end
+end

--- a/lib/mastodon/rest/featured_tags.rb
+++ b/lib/mastodon/rest/featured_tags.rb
@@ -1,0 +1,36 @@
+require 'mastodon/rest/utils'
+require 'mastodon/featured_tag'
+require 'mastodon/hashtag'
+
+module Mastodon
+  module REST
+    module FeaturedTags
+      include Mastodon::REST::Utils
+
+      # View featured tags for the current user
+      # @return [Mastodon::Collection<Mastodon::FeaturedTag>]
+      def featured_tags
+        perform_request_with_collection(:get, '/api/v1/featured_tags', {}, Mastodon::FeaturedTag)
+      end
+
+      # Feature a tag
+      # @param name [String]
+      # @return [Mastodon::Collection<Mastodon::FeaturedTag>]
+      def feature_tag(name)
+        perform_request_with_object(:post, '/api/v1/featured_tags', {name: name}, Mastodon::FeaturedTag)
+      end
+
+      # Unfeature a tag
+      # @param tag_id [Integer]
+      def unfeature_tag(tag_id)
+        perform_request(:delete, "/api/v1/featured_tags/#{tag_id}")
+      end
+
+      # Get suggested tags to feature
+      # @return [Mastodon::Collection<Mastodon::Hashtag>]
+      def suggested_tags_to_feature
+        perform_request_with_collection(:get, '/api/v1/featured_tags/suggestions', {}, Mastodon::Hashtag)
+      end
+    end
+  end
+end

--- a/lib/mastodon/rest/featured_tags.rb
+++ b/lib/mastodon/rest/featured_tags.rb
@@ -15,7 +15,7 @@ module Mastodon
 
       # Feature a tag
       # @param name [String]
-      # @return [Mastodon::Collection<Mastodon::FeaturedTag>]
+      # @return [Mastodon::FeaturedTag]
       def feature_tag(name)
         perform_request_with_object(:post, '/api/v1/featured_tags', {name: name}, Mastodon::FeaturedTag)
       end

--- a/lib/mastodon/rest/lists.rb
+++ b/lib/mastodon/rest/lists.rb
@@ -72,6 +72,13 @@ module Mastodon
       def remove_accounts_from_list(id, account_ids = [])
         perform_request(:delete, "/api/v1/lists/#{id}/accounts", { 'account_ids[]': account_ids })
       end
+
+      # Lists that you have added the given account ID to
+      # @param id [Integer]
+      # @return [Mastodon::Collection<Mastodon::List>]
+      def lists_containing_account(account_id)
+        perform_request_with_collection(:get, "/api/v1/accounts/#{account_id}/lists", {}, Mastodon::List)
+      end
     end
   end
 end

--- a/lib/mastodon/rest/notifications.rb
+++ b/lib/mastodon/rest/notifications.rb
@@ -19,6 +19,13 @@ module Mastodon
         perform_request_with_collection(:get, '/api/v1/notifications', options, Mastodon::Notification)
       end
 
+      # Get a single notification
+      # @param notification_id [Integer]
+      # @return Mastodon::Notification
+      def notification(notification_id)
+        perform_request_with_object(:get, "/api/v1/notifications/#{notification_id}", {}, Mastodon::Notification)
+      end
+
       # Dismiss a notification
       # @param id [Integer]
       def dismiss_notification(id)

--- a/lib/mastodon/rest/oauth.rb
+++ b/lib/mastodon/rest/oauth.rb
@@ -1,0 +1,35 @@
+require 'mastodon/rest/utils'
+require 'mastodon/access_token'
+
+module Mastodon
+  module REST
+    module OAuth
+      include Mastodon::REST::Utils
+
+      # Get an access token
+      # @param options [Hash]
+      # @option options :client_id [String]
+      # @option options :client_secret [String]
+      # @option options :redirect_uri [String]
+      # @option options :scope [String]
+      # @option options :code [String]
+      # @option options :grant_type [String]
+      # @return [Mastodon::Collection<Mastodon::AccessToken>]
+      def obtain_token(options = {})
+        perform_request_with_object(:post, '/api/v1/oauth/token', options, Mastodon::AccessToken)
+      end
+
+      # Revoke a token
+      # @param options [Hash]
+      # @option options :client_id [String]
+      # @option options :client_secret [String]
+      # @option options :token [String]
+      # @option options :scope [String]
+      # @option options :code [String]
+      # @option options :grant_type [String]
+      def revoke_token(options = {})
+        perform_request(:post, '/api/v1/oauth/revoke', options)
+      end
+    end
+  end
+end

--- a/lib/mastodon/rest/oauth.rb
+++ b/lib/mastodon/rest/oauth.rb
@@ -14,7 +14,7 @@ module Mastodon
       # @option options :scope [String]
       # @option options :code [String]
       # @option options :grant_type [String]
-      # @return [Mastodon::Collection<Mastodon::AccessToken>]
+      # @return [Mastodon::AccessToken]
       def obtain_token(options = {})
         perform_request_with_object(:post, '/api/v1/oauth/token', options, Mastodon::AccessToken)
       end

--- a/lib/mastodon/rest/polls.rb
+++ b/lib/mastodon/rest/polls.rb
@@ -1,0 +1,31 @@
+require 'mastodon/rest/utils'
+require 'mastodon/poll'
+
+module Mastodon
+  module REST
+    module Polls
+      include Mastodon::REST::Utils
+
+      # View a poll
+      # @param options [Hash]
+      # @option options :client_id [String]
+      # @option options :client_secret [String]
+      # @option options :redirect_uri [String]
+      # @option options :scope [String]
+      # @option options :code [String]
+      # @option options :grant_type [String]
+      # @return [Mastodon::Poll]
+      def view_poll(poll_id)
+        perform_request_with_object(:get, "/api/v1/polls/#{poll_id}", {}, Mastodon::Poll)
+      end
+
+      # Vote on a poll
+      # @param poll_id [Integer]
+      # @param choices [Array<Integer>]
+      # @return [Mastodon::Poll]
+      def vote_on_poll(poll_id, choices = [])
+        perform_request_with_object(:post, "/api/v1/polls/#{poll_id}/votes", { 'choices[]': choices }, Mastodon::Poll)
+      end
+    end
+  end
+end

--- a/lib/mastodon/rest/push_subscriptions.rb
+++ b/lib/mastodon/rest/push_subscriptions.rb
@@ -1,0 +1,45 @@
+require 'mastodon/rest/utils'
+require 'mastodon/push_subscription'
+
+module Mastodon
+  module REST
+    module PushSubscriptions
+      include Mastodon::REST::Utils
+
+      # Subscribe to push notifications
+      # @param subscription [Hash]
+      # @option subscription :endpoint [String]
+      # @option subscription :keys [Hash]
+      # @option subscription :keys :p256dh [String]
+      # @option subscription :keys :auth [String]
+      # @param data [Hash]
+      # @option data :alerts [Hash]
+      # @option data :alerts :follow [Boolean]
+      # @option data :alerts :favourite [Boolean]
+      # @option data :alerts :reblog [Boolean]
+      # @option data :alerts :mention [Boolean]
+      # @option data :alerts :poll [Boolean]
+      # @return [Mastodon::PushSubscription]
+      def subscribe(subscription = {}, data = {})
+        perform_request_with_object(:post, '/api/v1/push/subscription', { 'subscription': subscription, 'data': data }, Mastodon::PushSubscription)
+      end
+
+      # Get the current subscription for the access token
+      # @return [Mastodon::PushSubscription]
+      def subscription
+        perform_request_with_object(:get, '/api/v1/push/subscription', {}, Mastodon::PushSubscription)
+      end
+
+      # Update the current subscription
+      # @return [Mastodon::PushSubscription]
+      def change_subscription(data = {})
+        perform_request_with_object(:put, '/api/v1/push/subscription', { 'data': data }, Mastodon::PushSubscription)
+      end
+
+      # Removes the current Web Push API subscription
+      def remove_subscription
+        perform_request(:delete, '/api/v1/push/subscription', {})
+      end
+    end
+  end
+end

--- a/lib/mastodon/rest/trends.rb
+++ b/lib/mastodon/rest/trends.rb
@@ -1,0 +1,17 @@
+require 'mastodon/rest/utils'
+require 'mastodon/hashtag'
+
+module Mastodon
+  module REST
+    module Trends
+      include Mastodon::REST::Utils
+
+      # Get trending tags within the past week
+      # @param limit [Integer]
+      # @return [Mastodon::Collection<Mastodon::Hashtag>]
+      def trending_tags(limit = 10)
+        perform_request_with_collection(:get, '/api/v1/trends', { 'limit': limit }, Mastodon::Hashtag)
+      end
+    end
+  end
+end


### PR DESCRIPTION
As noted in #49, I made a list of the endpoints that (at the time) I believed were missing.

After finding some time to sit down and go through the document, I think I've made the relevant adjustments to cover a large number of missing endpoints.

I apologise for the massive wall of text that's about to follow, but it documents where I've got to with filling in the gaps.

Unfortunately, this only covers the REST endpoints, not streaming endpoints. Additionally, these changes lack tests, which is also my fault. However, I didn't feel justified in spamming mastodon.social with test runs. Where possible, I have tested the endpoints manually using botsin.space as a test instance, and using `binding.irb` calls.

If there is anything that you would like me to do to aid the closure of #49, I will make it a priority from my perspective so that the gem can get a new release.

I don't typically use GitHub for development, so I also apologise if this is not correct behaviour.

<hr></hr>

## Endpoints I falsely stated were missing

- Accounts
  - Main account methods
    - Statuses
      - Method: `GET`
      - Route: `/api/v1/accounts/#{id}/statuses`
    - Feature on Profile (pins)
      - Method: `POST`
      - Route: `/api/v1/accounts/#{id}/pin`
    - Unfeature on Profile (unpin)
      - Method: `POST`
      - Route: `/api/v1/accounts/#{id}/unpin`
  - Suggestions
    - Follow suggestions
      - Method: `GET`
      - Route: `/api/v1/suggestions`
    - Remove a suggestion
      - Method: `DELETE`
      - Route: `/api/v1/suggestions/#{account_id}`
- Reports
  - Create a Report 
    - Method: `POST`
    - Route: `/api/v1/reports`
- Notifications
  - Main notification methods
    - Dismiss a single notification
      - Method: `POST`
      - Route: `/api/v1/notifications/#{id}/dismiss`

## Endpoints that I've implemented in the Gem

- Accounts
  - Main account methods
    - Lists
      - Method: `GET`
      - Route: `/api/v1/accounts/#{id}/lists`
    - Identity Proofs
      - Method: `GET`
      - Route: `/api/v1/accounts/#{id}/identity_proofs`
  - Favourites
    - Method: `GET`
    - Route: `/api/v1/favourites`
  - Featured Tags
    - View your featured tags
      - Method: `GET`
      - Route: `/api/v1/featured_tags`
    - Feature a tag
      - Method: `POST`
      - Route: `/api/v1/featured_tags`
    - Unfeature a tag
      - Method: `DELETE`
      - Route: `/api/v1/featured_tags/#{id}`
    - Suggested tags to feature
      - Method: `GET`
      - Route: `/api/v1/featured_tags/suggestions`
- Apps
  - OAuth
    - Obtain a Token
      - Method: `POST`
      - Route: `/api/v1/oauth/token`
    - Revoke token
      - Method: `POST`
      - Route: `/api/v1/oauth/revoke`
- Statuses
  - Polls
    - View a poll
      - Method: `GET`
      - Route: `/api/v1/polls/#{id}`
    - Vote on a poll
      - Method: `POST`
      - Route: `/api/v1/polls/#{id}/votes`
- Notifications
  - Main notification methods
    - Get a single notification
      - Method: `GET`
      - Route: `/api/v1/notifications/#{id}`
- Notifications
  - Push
    - Subscribe to push notifications
      - Method: `POST`
      - Route: `/api/v1/push/subscription`
    - Get current subscription
      - Method: `GET`
      - Route: `/api/v1/push/subscription`
    - Change types of notifications
      - Method: `PUT`
      - Route: `/api/v1/push/subscription`
    - Remove current subscription
      - Method: `DELETE`
      - Route: `/api/v1/push/subscription`
- Directory
  - View profile directory
    - Method: `GET`
    - Route `/api/v1/directory`
- Trends
  - Trending tags
    - Method: `GET`
    - Route: `/api/v1/trends`
- Announcements
  - View all announcements
    - Method: `GET`
    - Route: `/api/v1/announcements`
  - Dismiss an announcements
    - Method: `POST`
    - Route: `/api/v1/announcements/#{id}/dismiss`
  - Add reaction
    - Method: `PUT`
    - Route: `/api/v1/announcements/#{id}/reactions/#{name}`
  - Remove reaction
    - Method: `DELETE`
    - Route: `/api/v1/announcements/#{id}/reactions/#{name}`
 
## Endpoints I'm not sure about

- Accounts
  - Bookmarks (might be deprecated, not sure whether to bother to implement for Bookmarks)
    - Method: `GET`
    - Route: `/api/v1/bookmarks`
  - Reports (some of the documentation was missing, I think this API endpoint is missing/removed now)
    - File a report
      - Method: `GET`
      - Route: `/api/v1/reports`
  - Preferences (I think I can implement this, but I'm not sure how to represent this, because of the weird shaping of the response keys (`<string>:<string>:<string>`))
    - View user preferences
      - Method: `GET`
      - Route: `/api/v1/preferences`
- Apps
  - OAuth
    - Authorize (not sure about this, since the response is a string/page to fill in)
      - Method: `GET`
      - Route: `/api/v1/oauth/authorize`
- Statuses
  - Media
    - Update an attachment (Get an Attachment, before it is attached to a status and posted...) (Not sure how to represent this with the current object/request method calls - would have to have a `File` passed through to request)
      - Method: `GET`
      - Route: `/api/v1/media/#{id}`
    - Focal points
      - No direct API documentation exists for this
- Timelines
  - Markers (They return a hash -> object representation, not sure if this should return an object instead (`Mastodon::MarkerCollection` or similar), with sub-objects of `Mastodon::Marker`?)
    - Get saved timeline position
      - Method: `GET`
      - Route: `/api/v1/markers`
    - Save position in timeline
      - Method: `POST`
      - Route: `/api/v1/markers`
- Admin (not currently complete documentation for API, there's also an Admin CLI (though it would be useful to have Admin calls in a separate library))
- Proofs (not sure how to represent this, unless just to directly return the response)
  - View identity proof
    - Method: `GET`
    - Route: `/api/proofs`
- OEmbed (not sure how to represent this, unless just to directly return the response)
  - OEmbed as JSON
    - Method: `GET`
    - Route: `/api/oembed`