### PR TITLE
Bumped http dependency to ~>5.0

### DIFF
--- a/mastodon.gemspec
+++ b/mastodon.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = %w(lib)
   spec.version       = Mastodon::Version
 
-  spec.add_dependency 'http', '~> 4.0'
+  spec.add_dependency 'http', '~> 5.0'
   spec.add_dependency 'oj', '~> 3.7'
   spec.add_dependency 'addressable', '~> 2.6'
   spec.add_dependency 'buftok', '~> 0'


### PR DESCRIPTION
Was hitting this known bug in http 3.3.0: https://github.com/httprb/http/issues/640

I bumped the dependency to `~>5.0`. Tests result in the same output and my bug is fixed.